### PR TITLE
Set the license in the classifiers in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -93,6 +93,7 @@ setup(
     install_requires=get_install_requirements(INSTALL_REQUIRES, CHOOSE_INSTALL_REQUIRES),
     include_package_data=True,
     classifiers=[
+        "License :: OSI Approved :: MIT License",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",


### PR DESCRIPTION
Add "License :: OSI Approved :: MIT License" to the classifiers list in setup.py, matching the license in the LICENSE file. This enables tools to automatically extract the license information, for example when using the "pip-licenses" tool to generate a report of third-party sofware and licenses.