### PR TITLE
Add license="MIT" to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -92,6 +92,7 @@ setup(
     packages=find_packages(exclude=("tests",)),
     install_requires=get_install_requirements(INSTALL_REQUIRES, CHOOSE_INSTALL_REQUIRES),
     include_package_data=True,
+    license="MIT",
     classifiers=[
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python",


### PR DESCRIPTION
Add `license="MIT"` to the `setup()` call in `setup.py`, matching the license in the `LICENSE` file and the license classifier. This makes `pip show qudida` find the license information.

Fixes arsenyinfo/qudida#4.